### PR TITLE
Add "Sign in to print" instructions

### DIFF
--- a/guides-site/library/library-printing.md
+++ b/guides-site/library/library-printing.md
@@ -20,6 +20,10 @@ Instructions for printing are posted by the library's Ricoh printer in the far c
 
 3\. Using FCPS Chromebook: choose PRINT, then use menu slider to choose MOBILITY PRINTING, then PRINT.
 
+4\. A window _may_ appear asking "Sign in to print". Do not enter anything into the Username or Password fields; instead, select "Sign in with Google" and use your fcpsschools.net Google account.
+
+You can double check if the print job was sent by going to [papercut.fcps.edu](https://papercut.fcps.edu). Log in with yout FCPS credentials and select "Jobs Pending Release" on the left after signing in and see if your document appears. Sometimes, you may see the job be sent even if step 4 appeared to fail.
+
 ## Retrieving Print Job
 
 1\. Go to Ricoh printer in the corner of the library.


### PR DESCRIPTION
Added instructions for signing in with Google for printing and checking print job status.

Instructions are based on the flowchart hanging next to the printer in the library